### PR TITLE
Optimize last_user queries and polish for initial production release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Report Production Candidates
 
-This REDCap module creates and displays a list of REDCap projects that should be moved into production. This module is integrated with Stanford University's [Go to Prod plugin](https://github.com/aandresalvarez/go_to_prod) and provides an interface for REDCap Admins to contact owners of projects for follow up.
+This REDCap module creates and displays a list of REDCap projects that should probably be moved into production. This module is integrated with Stanford University's [Go to Prod plugin](https://github.com/aandresalvarez/go_to_prod) and provides an interface for REDCap Admins to contact owners of projects for follow up.
 
 ## Prerequisites
-- REDCap >= 8.0.0 (for versions < 8.0.0, [REDCap Modules](https://github.com/vanderbilt/redcap-external-modules) is required).
+- REDCap >= 8.0.3 (for versions < 8.0.3, [REDCap Modules](https://github.com/vanderbilt/redcap-external-modules) is required).
 - [go_to_prod plugin](https://github.com/aandresalvarez/go_to_prod) installed on your REDCap instance.
 
 ## System-level Installation
@@ -15,3 +15,9 @@ This REDCap module creates and displays a list of REDCap projects that should be
 
 ## Using this module
 Go to **Control Center > Report Production Candidates** and to view the reports. Admins can use the Go to Prod button to review the project's production readiness and move the project into production. They can also click on REDCap usernames within the report to send those users an email. This email can be pre-filled with a template via the module's configuration page.
+
+## Notes regarding initial load of the report
+
+Report Production Candidates can seem very slow on the initial load. Please be patient if the first display of report takes many minutes. On a large or old REDCap system this is completely normal. Fortunately this will only happen on the _very first_ load of the report.
+
+Report Production Candidates uses summary data about projects that can only be acquired through queries of some of the largest tables in the REDCap database. On a large REDCap system with lots of activity or lots of stored data, these tables have millions of records. To circumvent the delays caused by querying these tables, this module uses a nightly cron job to gather the summary data. It writes the summary data into a table it can quickly query when running the report. That said, when first enabling the module, that table is empty. The reporting script detects the empty table and starts the initial run of the cron job that refreshes the table. That is why the first load of the report is slow. Normal report display should be about 50 projects/second.

--- a/config.json
+++ b/config.json
@@ -19,9 +19,14 @@
           "institution": "University of Florida - CTSI"
       },
       {
-	  "name": "Marly Cormar",
-	  "email": "marlycormar@ufl.edu",
-	  "institution": "University of Florida - CTSI"
+          "name": "Tiago Bember",
+          "email": "tbembersimeao@ufl.edu",
+          "institution": "University of Florida - CTSI"
+      },
+      {
+          "name": "Marly Cormar",
+          "email": "marlycormar@ufl.edu",
+          "institution": "University of Florida - CTSI"
       }
     ],
     "links" : {

--- a/helper.php
+++ b/helper.php
@@ -21,14 +21,12 @@ function uid_to_username($uid) {
 }
 
 function get_last_user($pid) {
-  $result = ExternalModules::query("SELECT user FROM redcap_log_event as el inner join
-                                    redcap_user_rights as ur on el.user = ur.username and el.project_id = ur.project_id and ur.project_id=$pid
-                                    order by ts desc limit 1;");
+  $result = ExternalModules::query("SELECT last_user FROM " . TABLE_NAME . " where project_id=$pid");
   if (!$result) {
     return false;
   }
 
-  return $result->fetch_assoc()["user"];
+  return $result->fetch_assoc()["last_user"];
 }
 
  function get_user_email($username) {

--- a/helper.php
+++ b/helper.php
@@ -21,7 +21,9 @@ function uid_to_username($uid) {
 }
 
 function get_last_user($pid) {
-  $result = ExternalModules::query("SELECT user FROM redcap_log_event WHERE ts IN (SELECT MAX(ts) FROM redcap_log_event WHERE project_id='$pid' AND user != '[survey respondent]')");
+  $result = ExternalModules::query("SELECT user FROM redcap_log_event as el inner join
+                                    redcap_user_rights as ur on el.user = ur.username and el.project_id = ur.project_id and ur.project_id=$pid
+                                    order by ts desc limit 1;");
   if (!$result) {
     return false;
   }

--- a/report.php
+++ b/report.php
@@ -34,8 +34,7 @@ $sql = "SELECT
           AND (redcap_record_counts.record_count > 100
           OR redcap_project_stats.saved_attribute_count > 500)
           AND DATEDIFF(NOW(), redcap_projects.creation_time) > 30
-          order by redcap_project_stats.saved_attribute_count desc
-          limit 150";
+          order by redcap_project_stats.saved_attribute_count desc";
 
 $result = ExternalModules::query($sql);
 

--- a/report.php
+++ b/report.php
@@ -35,7 +35,7 @@ $sql = "SELECT
           OR redcap_project_stats.saved_attribute_count > 500)
           AND DATEDIFF(NOW(), redcap_projects.creation_time) > 30
           order by redcap_project_stats.saved_attribute_count desc
-          limit 35";
+          limit 150";
 
 $result = ExternalModules::query($sql);
 

--- a/report.php
+++ b/report.php
@@ -105,7 +105,7 @@ if($project["creator_username"]) {
       $link = $module->get_mailer_link($project["creator_email"], $project);
       echo "<td><a href='" . $link . "'>" . $project["creator_username"] . "</a></td>";
   } else {
-      echo "<td>Could not find creator's name</td>";
+      echo "<td></td>";
   }
 
   //print out project purpose and the when the most recent activity was

--- a/report.php
+++ b/report.php
@@ -33,7 +33,9 @@ $sql = "SELECT
           AND redcap_projects.purpose != 0
           AND (redcap_record_counts.record_count > 100
           OR redcap_project_stats.saved_attribute_count > 500)
-          AND DATEDIFF(NOW(), redcap_projects.creation_time) > 30";
+          AND DATEDIFF(NOW(), redcap_projects.creation_time) > 30
+          order by redcap_project_stats.saved_attribute_count desc
+          limit 35";
 
 $result = ExternalModules::query($sql);
 

--- a/report.php
+++ b/report.php
@@ -97,7 +97,7 @@ foreach ($data as $project) {
     $link = $module->get_mailer_link($project['project_pi_email'], $project);
     echo "<td><a href='" . $link . "'>" . $project["project_pi_firstname"] . " " . $project["project_pi_lastname"] . "</td>";
   } else {
-    echo "<td> No PI </td>";
+    echo "<td></td>";
   }
 
   //sometimes creators can not be found on the system so we format output accordingly

--- a/samples/email_configuration.md
+++ b/samples/email_configuration.md
@@ -37,11 +37,11 @@ Here is a sample message from a generic REDCap support team informing the recipi
 >
 > Body:
 >
-> The REDCap project "[project_title]", accessible at [project_home_url], may need some attention to assure your data is properly protected.  The amount of data stored within it suggests your data might be better protected if the project were moved into REDCap's production status. Production status turns on a data audit trail so that one can always answer the question "Who changed what when?". Production mode also allows data dictionary checks to be reviewed before implementation. REDCap's automated review can generate warnings whenever a data dictionary change would put data at risk and give you the option to reconsider those changes.
+> The REDCap project "[project\_title]", accessible at [project\_home\_url], may need some attention to assure your data is properly protected.  The amount of data stored within it suggests your data might be better protected if the project were moved into REDCap's production status. Production status turns on a data audit trail so that one can always answer the question "Who changed what when?". Production mode also allows data dictionary checks to be reviewed before implementation. REDCap's automated review can generate warnings whenever a data dictionary change would put data at risk and give you the option to reconsider those changes.
 >
 > We are contacting you directly to engage you in a discussion about whether this project should move to production and what steps would be needed to make that happen. We would have made the move to production ourselves, but our reports suggest the project may need some changes before it can safely be moved to production.
 >
-> If you are interested in the data protections production status affords your data, please use review tool at [go_prod_url] to check your project and address any issues found. Once all of the issues are addressed, click the "Request to move project to production" link at the Project Setup page and take the "Move the production survey checklist" that appears in the pop up box.
+> If you are interested in the data protections production status affords your data, please use the review tool at [go\_prod\_url] to check your project and address any issues found. Once all of the issues are addressed, click the "Request to move project to production" link at the Project Setup page and take the "Move the production survey checklist" that appears in the pop up box.
 >
 > Regards,
 > Your REDCap Support Team


### PR DESCRIPTION
The principle change is the addition of the last_user column to the project stats table in commit 2a864bc. The balance of the changes add polish to the report and better describe the initial user experience. 

To test this PR, follow these steps:

- [ ] Add multiple large projects to your system. These projects should have more than 100 records or more than 500 saved attributes.
- [ ] Make the projects "old".  To do this, change the creation date in the project to something more than 30 days in the past.  This command should help "update redcap_projects set creation_time = date_add(now(), INTERVAL -32 DAY);"
- [ ] Put these large projects into development status if they are not already.
- [ ] If you have table redcap_project_stats, drop it.
- [ ] Enable the module in the Control Panel
- [ ] "Production Candidates Report" link from the control panel. Verify a report of the large projects in development status is displayed.

This PR fixes issue #9 