### PR TITLE
Feature/integrate with goprod v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
 # Report Production Candidates
 
-This REDCap module creates and displays a list of REDCap projects that should probably be moved into production. This module is integrated with Stanford University's [Go to Prod plugin](https://github.com/aandresalvarez/go_to_prod) and provides an interface for REDCap Admins to contact owners of projects for follow up.
+This REDCap module creates and displays a list of REDCap projects that should probably be moved into production. This module is integrated with Stanford University's [goprod module](https://github.com/ctsit/goprod) and provides an interface for REDCap Admins to contact owners of projects for follow up.
 
 ## Prerequisites
 - REDCap >= 8.0.3 (for versions < 8.0.3, [REDCap Modules](https://github.com/vanderbilt/redcap-external-modules) is required).
-- A go\_to\_prod plugin installed on your REDCap instance:
-  - The original [go\_to\_prod plugin](https://github.com/aandresalvarez/go_to_prod)
-  - [goprod\_v2.0](https://github.com/aandresalvarez/goprod_v2.0) (not currently functional)
+- The [goprod module](https://github.com/ctsit/goprod) installed on your REDCap instance _and_ enabled on all projects.
 
 ## System-level Installation
 1. Clone this repo into `<redcap-root>/modules/report_production_candidates_v<module_version_number>`.
 2. Go to **Control Center > Manage External Modules** and enable _Report Production Candidates_.
 
 ## Configuration
-- Users must choose which version of the plugin they wish to use.
 - Users can optionally preload an email template that will be used when they click a username in the report.  See [Sample Email Configuration](samples/email_configuration.md) for an example.
 
 ## Using this module

--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@ This REDCap module creates and displays a list of REDCap projects that should pr
 
 ## Prerequisites
 - REDCap >= 8.0.3 (for versions < 8.0.3, [REDCap Modules](https://github.com/vanderbilt/redcap-external-modules) is required).
-- [go_to_prod plugin](https://github.com/aandresalvarez/go_to_prod) installed on your REDCap instance.
+- A go\_to\_prod plugin installed on your REDCap instance:
+  - The original [go\_to\_prod plugin](https://github.com/aandresalvarez/go_to_prod)
+  - [goprod\_v2.0](https://github.com/aandresalvarez/goprod_v2.0) (not currently functional)
 
 ## System-level Installation
 1. Clone this repo into `<redcap-root>/modules/report_production_candidates_v<module_version_number>`.
 2. Go to **Control Center > Manage External Modules** and enable _Report Production Candidates_.
 
 ## Configuration
+- Users must choose which version of the plugin they wish to use.
 - Users can optionally preload an email template that will be used when they click a username in the report.  See [Sample Email Configuration](samples/email_configuration.md) for an example.
 
 ## Using this module

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
    "name": "Report Production Candidates",
    "namespace": "ReportProductionCandidatesModule\\ExternalModule",
-   "description": "This REDCap module creates and displays a list of REDCap projects that should be moved into production. This module is integrated with Stanford University's <a href='https://github.com/aandresalvarez/go_to_prod'>Go to Prod plugin</a> and provides an interface for REDCap Admins to contact owners of projects for follow up. See the complete <b><a href='https://github.com/ctsit/report_production_candidates' target='_blank'>documentation</a></b> at <a href='https://github.com/ctsit/report_production_candidates' target='_blank'>https://github.com/ctsit/report_production_candidates</a>.",
+   "description": "This REDCap module creates and displays a list of REDCap projects that should be moved into production. This module is integrated with Stanford University's <a href='https://github.com/ctsit/goprod'>Go to Prod module</a> and provides an interface for REDCap Admins to contact owners of projects for follow up. See the complete <b><a href='https://github.com/ctsit/report_production_candidates' target='_blank'>documentation</a></b> at <a href='https://github.com/ctsit/report_production_candidates' target='_blank'>https://github.com/ctsit/report_production_candidates</a>.",
    "authors": [
         {
             "name": "Dileep Rajput",
@@ -44,22 +44,6 @@
         ]
     },
     "system-settings": [
-        {
-            "key": "goprod_version",
-            "name": "Go Prod Version",
-            "required": true,
-            "type": "radio",
-            "choices": [
-                {
-                    "value": "go_prod",
-                    "name": "go_prod"
-                },
-                {
-                    "value": "goprod_v2.0",
-                    "name": "goprod_v2.0"
-                }
-            ]
-        },
         {
             "key": "rpc_cc",
             "name": "CC address",

--- a/config.json
+++ b/config.json
@@ -27,6 +27,11 @@
             "name": "Marly Cormar",
             "email": "marlycormar@ufl.edu",
             "institution": "University of Florida - CTSI"
+        },
+        {
+            "name": "Kyle Chesney",
+            "email": "kyle.chesney@ufl.edu",
+            "institution": "University of Florida - CTSI"
         }
     ],
     "links" : {
@@ -39,6 +44,22 @@
         ]
     },
     "system-settings": [
+        {
+            "key": "goprod_version",
+            "name": "Go Prod Version",
+            "required": true,
+            "type": "radio",
+            "choices": [
+                {
+                    "value": "go_prod",
+                    "name": "go_prod"
+                },
+                {
+                    "value": "goprod_v2.0",
+                    "name": "goprod_v2.0"
+                }
+            ]
+        },
         {
             "key": "rpc_cc",
             "name": "CC address",

--- a/report.php
+++ b/report.php
@@ -75,7 +75,7 @@ $odd_row = true;
 foreach ($data as $project) {
 
   //process data into useful information
-  $project["go_prod_url"] = APP_PATH_WEBROOT_FULL . "plugins/" . $module->getSystemSetting('goprod_version') . "/?pid=" . $project["project_id"];
+  $project["go_prod_url"] = APP_PATH_WEBROOT_FULL . "redcap_v" . REDCAP_VERSION . "/ExternalModules/?prefix=goprod&page=index&pid=" . $project["project_id"];
   $project["project_home_url"] = APP_PATH_WEBROOT_FULL . "redcap_v" . REDCAP_VERSION . "/ProjectSetup/index.php?pid=" . $project["project_id"];
   $project["creator_username"] = uid_to_username($project["creator_id"]);
   $project["creator_email"] = get_user_email($project["creator_username"]);

--- a/report.php
+++ b/report.php
@@ -75,7 +75,7 @@ $odd_row = true;
 foreach ($data as $project) {
 
   //process data into useful information
-  $project["go_prod_url"] = APP_PATH_WEBROOT_FULL . "plugins/go_prod/?pid=" . $project["project_id"];
+  $project["go_prod_url"] = APP_PATH_WEBROOT_FULL . "plugins/" . $module->getSystemSetting('goprod_version') . "/?pid=" . $project["project_id"];
   $project["project_home_url"] = APP_PATH_WEBROOT_FULL . "redcap_v" . REDCAP_VERSION . "/ProjectSetup/index.php?pid=" . $project["project_id"];
   $project["creator_username"] = uid_to_username($project["creator_id"]);
   $project["creator_email"] = get_user_email($project["creator_username"]);


### PR DESCRIPTION
Introduced ability for users to switch to different `got_to_prod` plugin versions.

While the module functions, the `goprod_v2.0` plugin is not currently functional; it defaults to returning an error saying the Project ID is required. Editing the plugin to have a default value simply returns a blank page.