### PR TITLE
add filter to SQL to remove deleted projects from list

### DIFF
--- a/report.php
+++ b/report.php
@@ -30,6 +30,7 @@ $sql = "SELECT
             ON redcap_project_stats.project_id = redcap_record_counts.project_id
         WHERE
           redcap_projects.status = 0
+          AND redcap_projects.date_deleted IS NULL
           AND redcap_projects.purpose != 0
           AND (redcap_record_counts.record_count > 100
           OR redcap_project_stats.saved_attribute_count > 500)


### PR DESCRIPTION
Addresses issue #20

~~NB: I ran `vagrant destroy` since discovering this issue and was unable to recreate the issue with a new deleted project even before adding the `date_deleted IS NULL` filter (and disabling the record count and age requirements).  
Will need to be tested on a more mature `redcap_deployment` instance.~~

Just needed to wait for the cron to run, works as expected.